### PR TITLE
Created Docker Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.expo
+.expo-shared
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use Node.js as the base image
+FROM node:18
+
+
+WORKDIR /myApp
+
+
+COPY myApp/package*.json ./
+
+
+RUN npm install -g expo-cli @expo/ngrok
+
+
+COPY myApp ./
+
+
+EXPOSE 19000 8081

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+ expo-app:
+   container_name: project03-11
+   build: ./
+   ports:
+     - 8081:8081   # Metro Bundler for web
+     - 19000:19000   # Expo development server
+   environment:
+     - EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0
+   volumes:
+     - ./myApp:/myApp
+     - /myApp/node_modules
+   command: npx expo start --tunnel

--- a/myApp/App.js
+++ b/myApp/App.js
@@ -4,7 +4,7 @@ import { StyleSheet, Text, View } from 'react-native';
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
+      <Text>Open up App.js to start working on your app! Test</Text>
       <StatusBar style="auto" />
     </View>
   );


### PR DESCRIPTION
This pull request creates the dockerfile as well as a docker-compose file to easily run within a docker container. To run, go to terminal and run `docker-compose up` from the project root directory. From there, the web version of the app will load on localhost 8081. 

<img width="471" alt="dockerRun2" src="https://github.com/user-attachments/assets/0d1d39d8-7e5c-4bf9-a54d-a9898e7ad4dc">

<img width="500" alt="dockerRun1" src="https://github.com/user-attachments/assets/7030f1e8-0486-43fc-94f2-5448b2bbcb87">


Note: Currently, only the web app is in docker. I have been unable to get the mobile app to work in the container

Resolves issue #2 